### PR TITLE
Dockerfile fixes needed after renaming toolebpflow to ebpflowexport

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN echo "deb [trusted=yes] http://repo.iovisor.org/apt/bionic bionic-nightly ma
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libcurl4-openssl-dev libjson-c-dev libzmq3-dev
 
-COPY toolebpflow /usr/share/
+COPY ebpflowexport /usr/share/
 
-ENTRYPOINT ["/usr/share/toolebpflow"]
+ENTRYPOINT ["/usr/share/ebpflowexport"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN echo "deb [trusted=yes] http://repo.iovisor.org/apt/bionic bionic-nightly ma
   apt-get update -y && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y bcc-tools
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libcurl4-openssl-dev libjson-c-dev libzmq3-dev
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libcurl4-openssl-dev libjson-c-dev libzmq3-dev libbpfcc-dev
 
 COPY ebpflowexport /usr/share/
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ $ docker run -it --rm --privileged \
   -v /etc/localtime:/etc/localtime:ro \
   -v /sys/kernel/debug:/sys/kernel/debug \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -v /snap/bin/microk8s.ctr:/snap/bin/microk8s.ctr \ 
+  -v /snap/bin/microk8s.ctr:/snap/bin/microk8s.ctr \
   ebpflowexport
 ```
 


### PR DESCRIPTION
Since toolebpflow was renamed ebpflowexport, Dockerfile has to be updated accordingly. Also, it was missing libbpfcc-dev dependency, causing ebpflowexport container to crash.